### PR TITLE
Update sentencepiece

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ctranslate2==1.17.1
-sentencepiece==0.1.91
+sentencepiece==0.1.94
 stanza==1.1.1
 PyQt5==5.15.1
 requests==2.25.1


### PR DESCRIPTION
This PR updates the `sentencepiece` package to solve the issue reported in https://github.com/argosopentech/argos-translate/issues/36

I don't think there were any API changes in between updates to the library, so things should work OK (they seem to be working fine after testing).

I'm still unsure why I couldn't just use the `0.1.91` version, but PyPI/pip sometimes is full of mysteries...