### PR TITLE
Replace "→" in the python code with old "->"

### DIFF
--- a/argostranslate/package.py
+++ b/argostranslate/package.py
@@ -103,7 +103,7 @@ class IPackage:
                 self.to_name == other.to_name
 
     def __str__(self):
-        return "{} → {}".format(self.from_name, self.to_name)
+        return "{} -> {}".format(self.from_name, self.to_name)
 
 
 class Package(IPackage):


### PR DESCRIPTION
The change to "→" might affect the extensibility of the code later (e.g. using the `str()` of the object for dict indexes).
Using "->" would be safer.
Further info/discussion here:
* https://github.com/argosopentech/argos-translate/commit/af115d608ff59ff328f45063b9f60b10761f271d#r48287176