### PR TITLE
Bugfix: Invalidate cache after `nresults` parameter changes

### DIFF
--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -207,7 +207,9 @@ class CachedTranslation(ITranslation):
         translated_paragraphs = []
         for paragraph in paragraphs:
             translated_paragraph = self.cache.get(paragraph)
-            if translated_paragraph == None:
+            # If len() < nresult, it means the `nresults` parameter has changed.
+            # We want to re-do the search and re-cache it in this case
+            if translated_paragraph == None or len(translated_paragraph) < nresults:
                 translated_paragraph = self.underlying.multi_translate(paragraph, nresults)
             new_cache[paragraph] = translated_paragraph
             translated_paragraphs.append(translated_paragraph)


### PR DESCRIPTION
When the `nresults` changes, in another call of `.translate()`, we possibly have cached translations that
are searched with different beam_search parameters, and also stored in
lists with different length.
The latter becomes problem when combining paragraphs.
So in this case we re-do the search with new parameter(s), and cache the
result.