### PR TITLE
Error --> Exception fix

### DIFF
--- a/argostranslate/package.py
+++ b/argostranslate/package.py
@@ -163,7 +163,7 @@ def install_from_path(path):
 
     """
     if not zipfile.is_zipfile(path):
-        raise Error('Not a valid Argos Model (must be a zip archive)')
+        raise Exception('Not a valid Argos Model (must be a zip archive)')
     with zipfile.ZipFile(path, 'r') as zip:
         zip.extractall(path=settings.package_data_dir)
 


### PR DESCRIPTION
Notice this little bug today; `Error` is not a valid type in Python (I think `Exception` was meant here?).