### PR TITLE
Add abbreviated names for commands

### DIFF
--- a/argostranslate/cli.py
+++ b/argostranslate/cli.py
@@ -2,17 +2,20 @@ import argparse
 import sys
 from argostranslate import package, translate
 
+
 def main():
     # Parse args
     parser = argparse.ArgumentParser()
     parser.add_argument('text', nargs='?', help='The text to translate')
-    parser.add_argument('--from-lang',
-            help='The code for the language to translate from (ISO 639-1)')
-    parser.add_argument('--to-lang',
-            help='The code for the language to translate to (ISO 639-1)')
+    parser.add_argument(
+        '-f', '--from-lang', help='The code for the language to translate from (ISO 639-1)'
+    )
+    parser.add_argument(
+        '-t', '--to-lang', help='The code for the language to translate to (ISO 639-1)'
+    )
     args = parser.parse_args()
 
-    from_and_to_lang_provided = args.from_lang != None and args.to_lang != None
+    from_and_to_lang_provided = args.from_lang is not None and args.to_lang is not None
 
     # Get text to translate
     if args.text:
@@ -45,11 +48,9 @@ def main():
         to_lang = installed_languages[to_lang_index]
         translation = from_lang.get_translation(to_lang)
         if translation == None:
-            sys.exit('No translation installed from {} to {}'.format(
-                    args.from_name, args.to_name))
+            raise Exception(f'No translation installed from {args.from_name} to {args.to_name}')
     else:
         translation = translate.IdentityTranslation('')
 
     # Print translation
     print(translation.translate(text_to_translate))
-


### PR DESCRIPTION
- Change sys.exit to raise exception
- Check if args.from_lang and args.from_lang are None, rather than if
    they are equal to None