### PR TITLE
Removed pytest from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ctranslate2==1.17.1
 sentencepiece==0.1.94
 stanza==1.1.1
-pytest==6.1.2
 PyQt5==5.15.4


### PR DESCRIPTION
This package does not require pytest to execute. It is only for test the package. If pytest in `requirements.txt`, It will also download along with this package.