### PR TITLE
Added tab completion for Bash

### DIFF
--- a/tab_completions/completion.bash
+++ b/tab_completions/completion.bash
@@ -1,0 +1,26 @@
+#/usr/bin/env bash
+
+# Tab Completion for argostranslate
+_argostranslate_completions ()  
+{
+  local cur
+
+  COMPREPLY=()
+  cur=${COMP_WORDS[COMP_CWORD]}
+
+  COMPREPLY=( $( compgen -W '--from-lang --to-lang --help' -- $cur ) )
+
+  case "$cur" in
+    -*)
+    COMPREPLY=( $( compgen -W '--from-lang --to-lang --help' -- $cur ) );;
+
+    ?)
+    COMPREPLY=( $( compgen -W 'en ar zh nl fr de hi id ga it ja ko pl pt ru es tr uk vi' -- $cur ) );;
+
+  esac
+
+  return 0
+}
+
+
+complete -F _argostranslate_completions argos-translate argos-translate-cli

--- a/tab_completions/completion.bash
+++ b/tab_completions/completion.bash
@@ -23,4 +23,16 @@ _argostranslate_completions ()
 }
 
 
+# Tab Completion for argospm
+_argospm_completions ()
+{
+  local cur
+
+  COMPREPLY=($(compgen -W "update install list remove help" "${COMP_WORDS[1]}"))
+
+  return 0
+}
+
+
+complete -F _argospm_completions argospm
 complete -F _argostranslate_completions argos-translate argos-translate-cli


### PR DESCRIPTION
closes #104 
Added Tab Completion script for argospm, argos-translate

To Enable and check this, run 

```bash
$ curl -sSL https://raw.githubusercontent.com/yogeshwaran01/argos-translate/master/tab_completions/completion.bash > /etc/bash_completion.d/argospm.bash
```
And restart the shell to run with completions