### PR TITLE
Upgrade to Stanza 1.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ctranslate2==2.5.1
 sentencepiece==0.1.96
-stanza==1.1.1
+stanza==1.2.3
 PyQt5==5.15.4


### PR DESCRIPTION
I just updated to a more recent version I was able to update to version 1.2.3 and the translation works without problems via the CLI. The latest version of Stanza 1.3.0 throws an error however.

Is there any other check to be made to make sure everything is working fine?