### PR TITLE
Use namespaced logger

### DIFF
--- a/argostranslate/utils.py
+++ b/argostranslate/utils.py
@@ -2,14 +2,14 @@ import logging
 
 from argostranslate import settings
 
-logging.basicConfig(level=logging.DEBUG if settings.debug else logging.INFO)
-
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG if settings.debug else logging.INFO)
 
 def info(*argv):
     """Info level log"""
-    logging.debug(str(argv))
+    logger.debug(str(argv))
 
 
 def error(*argv):
     """Error level log"""
-    logging.error(str(argv))
+    logger.error(str(argv))


### PR DESCRIPTION
[Python's doc](https://docs.python.org/3/library/logging.html) summarizes well why this is a must have:

> [...] Loggers should NEVER be instantiated directly, but always through the module-level function logging.getLogger(name). Multiple calls to [getLogger()](https://docs.python.org/3/library/logging.html#logging.getLogger) with the same name will always return a reference to the same Logger object. [...] The logger name hierarchy is analogous to the Python package hierarchy, and identical to it if you organise your loggers on a per-module basis using the recommended construction `logging.getLogger(__name__)`. That’s because in a module, `__name__` is the module’s name in the Python package namespace.