### PR TITLE
add two helpers functions

### DIFF
--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -555,21 +555,13 @@ def get_installed_languages():
     return languages
 
 def get_language_by_iso_code(iso_code):
-    wanted_language = list(filter(
+    return list(filter(
         lambda x: x.code == iso_code,
-        get_installed_languages()))
-
-    if len(wanted_language) and isinstance(wanted_language[0], Language):
-        return wanted_language[0]
-
-    return False
+        get_installed_languages()))[0]
 
 def get_translation_by_iso_codes(from_iso_code, to_iso_code):
     from_lang = get_language_by_iso_code(from_iso_code)
     to_lang = get_language_by_iso_code(to_iso_code)
-
-    if from_lang == False or to_lang == False:
-        return False
 
     return from_lang.get_translation(to_lang)
 

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -554,6 +554,24 @@ def get_installed_languages():
 
     return languages
 
+def get_package_by_iso_code(iso_code):
+    wanted_package = list(filter(
+        lambda x: x.code == iso_code,
+        get_installed_languages()))
+
+    if len(wanted_package) and isinstance(wanted_package[0], Language):
+        return wanted_package[0]
+
+    return False
+
+def get_translation_by_iso_codes(from_iso_code, to_iso_code):
+    from_lang = get_package_by_iso_code(from_iso_code)
+    to_lang = get_package_by_iso_code(to_iso_code)
+
+    if from_lang == False or to_lang == False:
+        return False
+
+    return from_lang.get_translation(to_lang)
 
 def load_installed_languages():
     """Deprecated 1.2, use get_installed_languages"""

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -554,19 +554,19 @@ def get_installed_languages():
 
     return languages
 
-def get_package_by_iso_code(iso_code):
-    wanted_package = list(filter(
+def get_language_by_iso_code(iso_code):
+    wanted_language = list(filter(
         lambda x: x.code == iso_code,
         get_installed_languages()))
 
-    if len(wanted_package) and isinstance(wanted_package[0], Language):
-        return wanted_package[0]
+    if len(wanted_language) and isinstance(wanted_language[0], Language):
+        return wanted_language[0]
 
     return False
 
 def get_translation_by_iso_codes(from_iso_code, to_iso_code):
-    from_lang = get_package_by_iso_code(from_iso_code)
-    to_lang = get_package_by_iso_code(to_iso_code)
+    from_lang = get_language_by_iso_code(from_iso_code)
+    to_lang = get_language_by_iso_code(to_iso_code)
 
     if from_lang == False or to_lang == False:
         return False

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -78,14 +78,14 @@ class TestPackage:
 
 
 class TestGetPackage:
-    def test_get_package_by_iso_code(self):
-        pck = argostranslate.translate.get_package_by_iso_code("fr")
+    def test_get_language_by_iso_code(self):
+        pck = argostranslate.translate.get_language_by_iso_code("fr")
 
         assert isinstance(pck, argostranslate.translate.Language)
         assert str(pck) == "French"
 
-    def test_get_package_by_iso_code_with_bad_iso_code(self):
-        pck = argostranslate.translate.get_package_by_iso_code("aa")
+    def test_get_language_by_iso_code_with_bad_iso_code(self):
+        pck = argostranslate.translate.get_language_by_iso_code("aa")
 
         assert pck == False
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -79,10 +79,9 @@ class TestPackage:
 
 class TestGetPackage:
     def test_get_language_by_iso_code(self):
-        pck = argostranslate.translate.get_language_by_iso_code("fr")
+        pck = argostranslate.translate.get_language_by_iso_code("en")
 
         assert isinstance(pck, argostranslate.translate.Language)
-        assert str(pck) == "French"
 
     def test_get_language_by_iso_code_with_bad_iso_code(self):
         pck = argostranslate.translate.get_language_by_iso_code("aa")
@@ -91,7 +90,7 @@ class TestGetPackage:
 
 class TestGetTranslation:
     def test_get_translation_by_iso_codes(self):
-        translation = argostranslate.translate.get_translation_by_iso_codes("fr", "en")
+        translation = argostranslate.translate.get_translation_by_iso_codes("en", "es")
 
         assert isinstance(translation, argostranslate.translate.ITranslation)
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -75,26 +75,3 @@ class TestPackage:
 
     def test_get_description(self):
         self.package.get_description() == self.readme
-
-
-class TestGetPackage:
-    def test_get_language_by_iso_code(self):
-        pck = argostranslate.translate.get_language_by_iso_code("en")
-
-        assert isinstance(pck, argostranslate.translate.Language)
-
-    def test_get_language_by_iso_code_with_bad_iso_code(self):
-        pck = argostranslate.translate.get_language_by_iso_code("aa")
-
-        assert pck == False
-
-class TestGetTranslation:
-    def test_get_translation_by_iso_codes(self):
-        translation = argostranslate.translate.get_translation_by_iso_codes("en", "es")
-
-        assert isinstance(translation, argostranslate.translate.ITranslation)
-
-    def test_get_translation_by_iso_codes_with_bad_iso_codes(self):
-        translation = argostranslate.translate.get_translation_by_iso_codes("fr", "bb")
-
-        assert translation == False

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,3 +1,4 @@
+import argostranslate
 from argostranslate import package
 import pytest
 
@@ -74,3 +75,27 @@ class TestPackage:
 
     def test_get_description(self):
         self.package.get_description() == self.readme
+
+
+class TestGetPackage:
+    def test_get_package_by_iso_code(self):
+        pck = argostranslate.translate.get_package_by_iso_code("fr")
+
+        assert isinstance(pck, argostranslate.translate.Language)
+        assert str(pck) == "French"
+
+    def test_get_package_by_iso_code_with_bad_iso_code(self):
+        pck = argostranslate.translate.get_package_by_iso_code("aa")
+
+        assert pck == False
+
+class TestGetTranslation:
+    def test_get_translation_by_iso_codes(self):
+        translation = argostranslate.translate.get_translation_by_iso_codes("fr", "en")
+
+        assert isinstance(translation, argostranslate.translate.ITranslation)
+
+    def test_get_translation_by_iso_codes_with_bad_iso_codes(self):
+        translation = argostranslate.translate.get_translation_by_iso_codes("fr", "bb")
+
+        assert translation == False


### PR DESCRIPTION
This adds two functions:

**get_language_by_iso_code** and **get_translation_by_iso_codes**


```python

# get_language_by_iso_code(iso_code) helps to simplify:

from_code = "en"
to_code = "es"

# Translate
installed_languages = argostranslate.translate.get_installed_languages()
from_lang = list(filter(
	lambda x: x.code == from_code,
	installed_languages))[0]
to_lang = list(filter(
	lambda x: x.code == to_code,
	installed_languages))[0]

# by

from_code = "en"
to_code = "es"

from_lang = argostranslate.translate.get_language_by_iso_code(from_code)
to_lang = argostranslate.translate.get_language_by_iso_code(to_code)
```
```python

# get_translation_by_iso_codes(iso_code) helps to simplify:

from_code = "en"
to_code = "es"

# Translate
installed_languages = argostranslate.translate.get_installed_languages()
from_lang = list(filter(
	lambda x: x.code == from_code,
	installed_languages))[0]
to_lang = list(filter(
	lambda x: x.code == to_code,
	installed_languages))[0]
translation = from_lang.get_translation(to_lang)

# by

from_code = "en"
to_code = "es"

translation = argostranslate.translate.get_translation_by_iso_codes(from_code, to_code)
```