### PR TITLE
Feature: add sacrebleu script

### DIFF
--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -595,8 +595,8 @@ def get_translation_from_codes(from_code, to_code):
     Returns:
         translate.ITranslation: The translation object
     """
-    from_lang = get_language_by_iso_code(from_code)
-    to_lang = get_language_by_iso_code(to_code)
+    from_lang = get_language_from_code(from_code)
+    to_lang = get_language_from_code(to_code)
     return from_lang.get_translation(to_lang)
 
 

--- a/scripts/model_sacrebleu_score.py
+++ b/scripts/model_sacrebleu_score.py
@@ -39,15 +39,15 @@ def main():
 
     with open(source_file_path, "r") as source:
         lines = source.readlines()
-    source_lines = [line.strip() for line in lines]
-    source_lines_length = len(source_lines)
+        source_lines = [line.strip() for line in lines]
+        source_lines_length = len(source_lines)
 
-    for i, line in enumerate(source_lines):
-        translated = translate(line, from_lang, to_lang)
-        print('Translated ' + str(i) + ' lines of ' + str(source_lines_length) + ' lines')
+        for i, line in enumerate(source_lines):
+            translated = translate(line, from_lang, to_lang)
+            print('Translated ' + str(i) + ' lines of ' + str(source_lines_length) + ' lines')
 
-        output_file.write(translated.strip() + "\n")
-        output_file.flush()
+            output_file.write(translated.strip() + "\n")
+            output_file.flush()
 
     os.system(
         "sacrebleu -i " + output_file_path + " -t " + test_set + " -l " + lang_pair + ' >> ' + lang_pair + '.sacrebleu-score.json')

--- a/scripts/model_sacrebleu_score.py
+++ b/scripts/model_sacrebleu_score.py
@@ -1,0 +1,56 @@
+import argparse
+import os
+from pathlib import Path
+
+import sacrebleu
+
+from argostranslate.translate import translate
+
+
+def main():
+    parser = argparse.ArgumentParser(description="sacreBLEU score for a model")
+    parser.add_argument(
+        "--test-set",
+        "--t",
+        default="wmt17",
+        metavar="TEST_SET",
+        help="The test set",
+    )
+    parser.add_argument(
+        "--lang-pair",
+        "--l",
+        metavar="LANG_PAIR",
+        help="The lang pair of the model to test",
+    )
+    args = parser.parse_args()
+
+    test_set = args.test_set
+    lang_pair = args.lang_pair
+
+    splitted_lang_pair = lang_pair.split('-')
+    from_lang = splitted_lang_pair[0]
+    to_lang = splitted_lang_pair[1]
+
+    sacrebleu.download_test_set(test_set, lang_pair)
+    source_file_path = Path(sacrebleu.get_source_file(test_set, lang_pair))
+
+    output_file_path = test_set + '.output.' + lang_pair
+    output_file = open(output_file_path, "a+", encoding="utf-8")
+
+    with open(source_file_path, "r") as source:
+        lines = source.readlines()
+    source_lines = [line.strip() for line in lines]
+    source_lines_length = len(source_lines)
+
+    for i, line in enumerate(source_lines):
+        translated = translate(line, from_lang, to_lang)
+        print('Translated ' + str(i) + ' lines of ' + str(source_lines_length) + ' lines')
+
+        output_file.write(translated.strip() + "\n")
+        output_file.flush()
+
+    os.system(
+        "sacrebleu -i " + output_file_path + " -t " + test_set + " -l " + lang_pair + ' >> ' + lang_pair + '.sacrebleu-score.json')
+
+
+main()


### PR DESCRIPTION
I added a small script to easily obtain the BLEU score of a model with [sacreBLEU](https://github.com/mjpost/sacrebleu) 

Example:
```
python ./scripts/model_sacrebleu_score.py --lang-pair en-de
```

And this will automatically create an en-de.sacrebleu-score.json file with the result once the test is finished

Example of result (en-de):
```json
{
 "name": "BLEU",
 "score": 26.5,
 "signature": "nrefs:1|case:mixed|eff:no|tok:13a|smooth:exp|version:2.2.1",
 "verbose_score": "59.0/32.4/20.1/12.9 (BP = 1.000 ratio = 1.007 hyp_len = 61734 ref_len = 61287)",
 "nrefs": "1",
 "case": "mixed",
 "eff": "no",
 "tok": "13a",
 "smooth": "exp",
 "version": "2.2.1"
}
```
