### PR TITLE
fix: correct get_available_packages typing

### DIFF
--- a/argostranslate/package.py
+++ b/argostranslate/package.py
@@ -327,7 +327,7 @@ def update_package_index():
             f.write(data)
 
 
-def get_available_packages() -> list[Package]:
+def get_available_packages() -> list[AvailablePackage]:
     """Returns a list of AvailablePackages from the package index."""
 
     try:


### PR DESCRIPTION
Typing for get_available_packages is misleading, it returns an array of AvailablePackages.

This is generating errors on linters since Package does not possess "download" or "install" method.

This PR changes the return prototype of get_available_packages to [AvailablePackage] instead of [Package]