### PR TITLE
Update ctranslate2 to v3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ctranslate2==2.24.0
+ctranslate2==3.20.0
 sentencepiece==0.1.99
 stanza==1.1.1


### PR DESCRIPTION
Updating ctranslate2 would allow usage of language models trained with version 3 of OpenNMT-py. ctranslate2 seems backward compatible, as I can run the existing v2 models just fine with v3.