### PR TITLE
Use the new TranslationResult properties from ctranslate2

### DIFF
--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -479,8 +479,8 @@ def apply_packaged_translation(
         translated_tokens = []
         cumulative_score = 0
         for translated_batch in translated_batches:
-            translated_tokens += translated_batch[i]["tokens"]
-            cumulative_score += translated_batch[i]["score"]
+            translated_tokens += translated_batch.hypotheses[i]
+            cumulative_score += translated_batch.scores[i]
         
         value = pkg.tokenizer.decode(translated_tokens)
         


### PR DESCRIPTION
Hello,

I noticed a deprecation warning when running the `FewShotTranslation.apply_packaged_translation` method:

> DeprecationWarning: Reading the TranslationResult object as a list of dictionaries is deprecated and will be removed in a futur version. Please use the object attributes as described in the documentation: https://opennmt.net/CTranslate2/python/ctranslate2.TranslationResult.html

This could lead to an exception:

```
> translated_tokens += translated_batch[i]["tokens"]                                                             
SystemError: <built-in method __getitem__ of PyCapsule object at 0x7d8642cd7d80> returned a result with an exception set 
```

So I simply used the new properties as suggested by ctranslate2.

Let me know if you want me to add a safer access to the properties for retro-compatibility.

Thanks for the great tool!