### PR TITLE
Automatically download "xx_sent_ud_sm" if it doesn't exist

### DIFF
--- a/argostranslate/sbd.py
+++ b/argostranslate/sbd.py
@@ -24,7 +24,11 @@ class ISentenceBoundaryDetectionModel:
 # python -m spacy download xx_sent_ud_sm
 class SpacySentencizerSmall(ISentenceBoundaryDetectionModel):
     def __init__(self):
-        self.nlp = spacy.load("xx_sent_ud_sm")
+        try:
+         self.nlp = spacy.load("xx_sent_ud_sm")
+        except OSError:
+            spacy.cli.download("xx_sent_ud_sm")
+            self.nlp = spacy.load("xx_sent_ud_sm")
         self.nlp.add_pipe("sentencizer")
 
     def split_sentences(self, text: str, lang_code: Optional[str] = None) -> List[str]:


### PR DESCRIPTION
Basically, the title : 
On import if package is not downloaded spacy will throw:
`OSError: [E050] Can't find model 'xx_sent_ud_sm'. It doesn't seem to be a Python package or a valid path to a data directory.`

This just catches the error and tries to download package