### PR TITLE
[argospm] Show help if no argument is given

### DIFF
--- a/argostranslate/argospm.py
+++ b/argostranslate/argospm.py
@@ -141,4 +141,7 @@ def main():
     remove_parser.add_argument("name", help="Package name")
 
     args = parser.parse_args()
-    args.callback(args)
+    if(hasattr(args, "callback")):
+        args.callback(args)
+    else:
+        parser.print_help()


### PR DESCRIPTION
Currently throwing an error (Python 3.9.4)
![imagen](https://github.com/user-attachments/assets/0a4f86b6-3585-4198-be98-8733e1b46868)

After change, show help
![imagen](https://github.com/user-attachments/assets/81b9d0a5-2129-409e-b514-110c84c10208)

Feel free to solve it in a better way. Just throwing a quick fix