### PR TITLE
Added specific method to  languages() API function

### DIFF
--- a/argostranslate/apis.py
+++ b/argostranslate/apis.py
@@ -79,7 +79,7 @@ class LibreTranslateAPI:
 
         url_params = parse.urlencode(params)
 
-        req = request.Request(url, data=url_params.encode())
+        req = request.Request(url, data=url_params.encode(), method="GET")
 
         response = request.urlopen(req)
 


### PR DESCRIPTION
Fixes #449 
This PR specifies 'GET' method to languages() request, avoiding `405 HTTP ERROR`