### PR TITLE
Optimizations

### DIFF
--- a/argostranslate/argospm.py
+++ b/argostranslate/argospm.py
@@ -141,7 +141,7 @@ def main():
     remove_parser.add_argument("name", help="Package name")
 
     args = parser.parse_args()
-    if(hasattr(args, "callback")):
+    if hasattr(args, "callback"):
         args.callback(args)
     else:
         parser.print_help()

--- a/argostranslate/package.py
+++ b/argostranslate/package.py
@@ -262,6 +262,10 @@ def install_from_path(path: Path):
             raise Exception("Not a valid Argos Model (must be a zip archive)")
         with zipfile.ZipFile(path, "r") as zipf:
             zipf.extractall(path=settings.package_data_dir)
+        
+        # Clear language cache after package installation
+        from argostranslate.translate import get_installed_languages
+        get_installed_languages.cache_clear()
 
 
 class AvailablePackage(IPackage):
@@ -316,6 +320,10 @@ def uninstall(pkg: Package):
     """
     with package_lock:
         shutil.rmtree(pkg.package_path)
+        
+        # Clear language cache after package uninstallation
+        from argostranslate.translate import get_installed_languages
+        get_installed_languages.cache_clear()
 
 
 def get_installed_packages(path: Path = None) -> list[Package]:

--- a/argostranslate/package.py
+++ b/argostranslate/package.py
@@ -262,9 +262,10 @@ def install_from_path(path: Path):
             raise Exception("Not a valid Argos Model (must be a zip archive)")
         with zipfile.ZipFile(path, "r") as zipf:
             zipf.extractall(path=settings.package_data_dir)
-        
+
         # Clear language cache after package installation
         from argostranslate.translate import get_installed_languages
+
         get_installed_languages.cache_clear()
 
 
@@ -320,9 +321,10 @@ def uninstall(pkg: Package):
     """
     with package_lock:
         shutil.rmtree(pkg.package_path)
-        
+
         # Clear language cache after package uninstallation
         from argostranslate.translate import get_installed_languages
+
         get_installed_languages.cache_clear()
 
 

--- a/argostranslate/settings.py
+++ b/argostranslate/settings.py
@@ -171,6 +171,7 @@ inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))
 intra_threads = int(get_setting("ARGOS_INTRA_THREADS", "0"))
 batch_size = int(get_setting("ARGOS_BATCH_SIZE", "32"))
 compute_type = get_setting("ARGOS_COMPUTE_TYPE", "auto")
+beam_size = int(get_setting("ARGOS_BEAM_SIZE", "4"))
 
 
 class ModelProvider(Enum):

--- a/argostranslate/settings.py
+++ b/argostranslate/settings.py
@@ -169,6 +169,7 @@ device = get_setting("ARGOS_DEVICE_TYPE", "cpu")
 # https://opennmt.net/CTranslate2/python/ctranslate2.Translator.html
 inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))
 intra_threads = int(get_setting("ARGOS_INTRA_THREADS", "0"))
+batch_size = int(get_setting("ARGOS_BATCH_SIZE", "32"))
 
 
 class ModelProvider(Enum):

--- a/argostranslate/settings.py
+++ b/argostranslate/settings.py
@@ -170,6 +170,7 @@ device = get_setting("ARGOS_DEVICE_TYPE", "cpu")
 inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))
 intra_threads = int(get_setting("ARGOS_INTRA_THREADS", "0"))
 batch_size = int(get_setting("ARGOS_BATCH_SIZE", "32"))
+compute_type = get_setting("ARGOS_COMPUTE_TYPE", "auto")
 
 
 class ModelProvider(Enum):

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -495,7 +495,7 @@ def apply_packaged_translation(
         target_prefix=target_prefix,
         replace_unknowns=True,
         max_batch_size=settings.batch_size,
-        beam_size=min(max(num_hypotheses, 1), 4),
+        beam_size=max(num_hypotheses, 4),
         num_hypotheses=num_hypotheses,
         length_penalty=0.2,
         return_scores=True,

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -495,6 +495,7 @@ def apply_packaged_translation(
         target_prefix=target_prefix,
         replace_unknowns=True,
         max_batch_size=settings.batch_size,
+        batch_type="tokens",
         beam_size=max(num_hypotheses, settings.beam_size),
         num_hypotheses=num_hypotheses,
         length_penalty=0.2,

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -480,7 +480,6 @@ def apply_packaged_translation(
     info("tokenized", tokenized)
 
     # Translation
-    BATCH_SIZE = 32
     target_prefix = None
 
     if pkg.target_prefix != "":
@@ -490,8 +489,8 @@ def apply_packaged_translation(
         tokenized,
         target_prefix=target_prefix,
         replace_unknowns=True,
-        max_batch_size=BATCH_SIZE,
-        beam_size=max(num_hypotheses, 4),
+        max_batch_size=settings.batch_size,
+        beam_size=min(max(num_hypotheses, 1), 4),
         num_hypotheses=num_hypotheses,
         length_penalty=0.2,
         return_scores=True,
@@ -504,7 +503,7 @@ def apply_packaged_translation(
         translated_tokens = []
         cumulative_score = 0
         for translated_batch in translated_batches:
-            translated_tokens += translated_batch.hypotheses[i]
+            translated_tokens.extend(translated_batch.hypotheses[i])
             cumulative_score += translated_batch.scores[i]
 
         value = pkg.tokenizer.decode(translated_tokens)

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List
+import functools
 
 import ctranslate2
 # import sentencepiece as spm
@@ -536,6 +537,7 @@ class InstalledTranslate:
 installed_translates: List[InstalledTranslate] = []
 
 
+@functools.lru_cache()
 def get_installed_languages() -> list[Language]:
     """Returns a list of Languages installed from packages"""
 

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import List
 import functools
+from typing import List
 
 import ctranslate2
 # import sentencepiece as spm

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -180,6 +180,7 @@ class PackageTranslation(ITranslation):
                 device=settings.device,
                 inter_threads=settings.inter_threads,
                 intra_threads=settings.intra_threads,
+                compute_type=settings.compute_type,
             )
         paragraphs = ITranslation.split_into_paragraphs(input_text)
         info("paragraphs:", paragraphs)

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -495,7 +495,7 @@ def apply_packaged_translation(
         target_prefix=target_prefix,
         replace_unknowns=True,
         max_batch_size=settings.batch_size,
-        beam_size=max(num_hypotheses, 4),
+        beam_size=max(num_hypotheses, settings.beam_size),
         num_hypotheses=num_hypotheses,
         length_penalty=0.2,
         return_scores=True,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -24,3 +24,33 @@ export ARGOS_PACKAGES_DIR="/home/user/.local/share/argos-translate/packages/"
 export ARGOS_DEVICE_TYPE="cpu"
 export ARGOS_DEVICE_TYPE="cuda"
 ```
+
+### Performance Settings
+
+#### Model precision and quantization
+```
+export ARGOS_COMPUTE_TYPE="auto"         # Default
+export ARGOS_COMPUTE_TYPE="float32"      # Highest accuracy
+export ARGOS_COMPUTE_TYPE="int8"         # Fastest, some accuracy loss
+export ARGOS_COMPUTE_TYPE="int8_float32" # Best balance of speed/accuracy
+```
+
+#### Threading configuration
+```
+export ARGOS_INTER_THREADS=1       # Number of parallel translators (default: 1)
+export ARGOS_INTRA_THREADS=0       # Threads per translator (default: 0 = auto-detect)
+```
+
+#### Batch processing
+```
+export ARGOS_BATCH_SIZE=32         # Translation batch size (default: 32)
+```
+
+#### Sentence boundary detection
+```
+export ARGOS_CHUNK_TYPE="DEFAULT"       # Default behavior
+export ARGOS_CHUNK_TYPE="ARGOSTRANSLATE" # Use Argos Translate's SBD
+export ARGOS_CHUNK_TYPE="STANZA"        # Use Stanza for sentence splitting
+export ARGOS_CHUNK_TYPE="SPACY"         # Use SpaCy for sentence splitting
+export ARGOS_CHUNK_TYPE="NONE"          # No sentence splitting
+```


### PR DESCRIPTION
Inspired by https://opennmt.net/CTranslate2/performance.html 
Add LRU cache for language load (get_installed_languages is slow), quantization support, and configurable batch size.
Also, beam_size is set to be a minimum of 4. I am not sure if that's what we intended. 

Quantizations provided a nice little boost:
```
$ ARGOS_COMPUTE_TYPE="float32" python test_performance_es_to_en.py
Starting performance test: 10 iterations from es to en
Testing 12 phrases, total: 4849 characters
============================================================
Running warmup translation (not counted in timing)...
2025-08-19 04:00:34 WARNING: Unsupported language: az  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 04:00:36 WARNING: Unsupported language: eo  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 04:00:37 WARNING: Unsupported language: ms  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 04:00:38 WARNING: Unsupported language: tl  If trying to add a new language, consider using allow_unknown_language=True
Warmup complete. Sample result: Software development is a complex discipline that requires both technical skills and creativity. Pro...
------------------------------------------------------------
Iteration  1: 1.7180s (12 phrases)
Iteration  2: 1.3710s (12 phrases)
Iteration  3: 1.3931s (12 phrases)
Iteration  4: 1.2430s (12 phrases)
Iteration  5: 1.2463s (12 phrases)
Iteration  6: 1.2482s (12 phrases)
Iteration  7: 1.2442s (12 phrases)
Iteration  8: 1.2464s (12 phrases)
Iteration  9: 1.2449s (12 phrases)
Iteration 10: 1.2437s (12 phrases)
============================================================
PERFORMANCE RESULTS:
Average time:  1.3199s
Median time:   1.2464s
Min time:      1.2430s
Max time:      1.7180s
Std deviation: 0.1511s
Total time:    13.1988s
Per phrase:    0.1100s avg
============================================================
CONSISTENCY CHECK:
Identical translations: 12/12
✅ All translations are consistent!

$ ARGOS_COMPUTE_TYPE="int8" python test_performance_es_to_en.py
Starting performance test: 10 iterations from es to en
Testing 12 phrases, total: 4849 characters
============================================================
Running warmup translation (not counted in timing)...
2025-08-19 03:59:49 WARNING: Unsupported language: az  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 03:59:50 WARNING: Unsupported language: eo  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 03:59:52 WARNING: Unsupported language: ms  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 03:59:53 WARNING: Unsupported language: tl  If trying to add a new language, consider using allow_unknown_language=True
Warmup complete. Sample result: Software development is a complex discipline that requires both technical skills and creativity. Pro...
------------------------------------------------------------
Iteration  1: 0.8528s (12 phrases)
Iteration  2: 0.9388s (12 phrases)
Iteration  3: 0.9670s (12 phrases)
Iteration  4: 0.9757s (12 phrases)
Iteration  5: 0.9645s (12 phrases)
Iteration  6: 0.9738s (12 phrases)
Iteration  7: 0.9926s (12 phrases)
Iteration  8: 0.9770s (12 phrases)
Iteration  9: 0.9725s (12 phrases)
Iteration 10: 0.9594s (12 phrases)
============================================================
PERFORMANCE RESULTS:
Average time:  0.9574s
Median time:   0.9698s
Min time:      0.8528s
Max time:      0.9926s
Std deviation: 0.0393s
Total time:    9.5741s
Per phrase:    0.0798s avg
============================================================
CONSISTENCY CHECK:
Identical translations: 12/12
✅ All translations are consistent!

$ ARGOS_COMPUTE_TYPE="int8_float32" python test_performance_es_to_en.py
Starting performance test: 10 iterations from es to en
Testing 12 phrases, total: 4849 characters
============================================================
Running warmup translation (not counted in timing)...
2025-08-19 04:00:11 WARNING: Unsupported language: az  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 04:00:13 WARNING: Unsupported language: eo  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 04:00:14 WARNING: Unsupported language: ms  If trying to add a new language, consider using allow_unknown_language=True
2025-08-19 04:00:15 WARNING: Unsupported language: tl  If trying to add a new language, consider using allow_unknown_language=True
Warmup complete. Sample result: Software development is a complex discipline that requires both technical skills and creativity. Pro...
------------------------------------------------------------
Iteration  1: 0.8521s (12 phrases)
Iteration  2: 0.9387s (12 phrases)
Iteration  3: 0.9632s (12 phrases)
Iteration  4: 0.9646s (12 phrases)
Iteration  5: 0.9625s (12 phrases)
Iteration  6: 0.9556s (12 phrases)
Iteration  7: 0.9594s (12 phrases)
Iteration  8: 0.9666s (12 phrases)
Iteration  9: 0.9558s (12 phrases)
Iteration 10: 0.9581s (12 phrases)
============================================================
PERFORMANCE RESULTS:
Average time:  0.9477s
Median time:   0.9588s
Min time:      0.8521s
Max time:      0.9666s
Std deviation: 0.0345s
Total time:    9.4765s
Per phrase:    0.0790s avg
============================================================
CONSISTENCY CHECK:
Identical translations: 12/12
✅ All translations are consistent!
```

Increasing batch size didn't make any change in CPU (at least not in my testing); it might be different in GPU.