### PR TITLE
cli.py: fixing small bug

### DIFF
--- a/argostranslate/cli.py
+++ b/argostranslate/cli.py
@@ -54,7 +54,7 @@ def main():
         translation = from_lang.get_translation(to_lang)
         if translation is None:
             parser.error(
-                f"No translation installed from {args.from_name} to {args.to_name}"
+                f"No translation installed from {args.from_lang} to {args.to_lang}"
             )
     else:
         translation = translate.IdentityTranslation("")


### PR DESCRIPTION
Due to wrong variable names in the print, the program crashed in the following situation: translating from lang A to lang B, A -> B not installed, and B -> A installed.