### PR TITLE
Do not set compute type

### DIFF
--- a/argostranslate/settings.py
+++ b/argostranslate/settings.py
@@ -170,7 +170,6 @@ device = get_setting("ARGOS_DEVICE_TYPE", "cpu")
 inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))
 intra_threads = int(get_setting("ARGOS_INTRA_THREADS", "0"))
 batch_size = int(get_setting("ARGOS_BATCH_SIZE", "32"))
-compute_type = get_setting("ARGOS_COMPUTE_TYPE", "auto")
 beam_size = int(get_setting("ARGOS_BEAM_SIZE", "4"))
 
 

--- a/argostranslate/settings.py
+++ b/argostranslate/settings.py
@@ -170,6 +170,7 @@ device = get_setting("ARGOS_DEVICE_TYPE", "cpu")
 inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))
 intra_threads = int(get_setting("ARGOS_INTRA_THREADS", "0"))
 batch_size = int(get_setting("ARGOS_BATCH_SIZE", "32"))
+compute_type = get_setting("ARGOS_COMPUTE_TYPE", "auto")
 beam_size = int(get_setting("ARGOS_BEAM_SIZE", "4"))
 
 

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -186,12 +186,15 @@ class PackageTranslation(ITranslation):
     def hypotheses(self, input_text: str, num_hypotheses: int = 4) -> list[Hypothesis]:
         if self.translator is None:
             model_path = str(self.pkg.package_path / "model")
-            self.translator = ctranslate2.Translator(
-                model_path,
-                device=settings.device,
-                inter_threads=settings.inter_threads,
-                intra_threads=settings.intra_threads,
-            )
+            params = {
+                "model_path": model_path,
+                "device": settings.device,
+                "inter_threads": settings.inter_threads,
+                "intra_threads": settings.intra_threads,
+            }
+            if settings.compute_type != "auto":
+                params["compute_type"] = settings.compute_type
+            self.translator = ctranslate2.Translator(**params)
         paragraphs = ITranslation.split_into_paragraphs(input_text)
         info("paragraphs:", paragraphs)
         translated_paragraphs = []

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -191,7 +191,6 @@ class PackageTranslation(ITranslation):
                 device=settings.device,
                 inter_threads=settings.inter_threads,
                 intra_threads=settings.intra_threads,
-                compute_type=settings.compute_type,
             )
         paragraphs = ITranslation.split_into_paragraphs(input_text)
         info("paragraphs:", paragraphs)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 
 setup(
     name="argostranslate",
-    version="1.11.0",
+    version="1.11.1",
     description="Open-source neural machine translation library based on OpenNMT's CTranslate2",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR fixed a problem introduced with https://github.com/argosopentech/argos-translate/commit/5a9ec1eecb66856d51db740ac3ff1cc7ff3b0aa5 which broke support for certain models (e.g. Spanish). 

Ref: https://github.com/LibreTranslate/LibreTranslate/issues/930

The root cause is a quirky behavior of ctranslate2 which I remember encountering in #369, whereby setting the compute_type explicitly would cause certain models to return garbage.

Removing the explicit compute_type override and letting ctranslate2 figure out the appropriate value fixes the problem and restores the behavior of v1.9.6. 

```bash
[piero:~/Documents/argos-translate] [venv] master* ± ARGOS_DEBUG=1 ARGOS_CHUNK_TYPE=STANZA python test_trans.py
('get_installed_languages',)
('paragraphs:', ['Vamos'])
('apply_packaged_translation', 'Vamos')
('Splitting sentences using SBD Model: (es) StanzaSentencizer',)
('sentences', ['Vamos'])
('tokenized', [['Vamos']])
('translated_batches', [TranslationResult(hypotheses=[['mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@', 'mainstre@@']], scores=[-39.73262023925781], attention=[], logits=[])])
('value_hypotheses:', [('mainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstre@@', -39.73262023925781)])
('translated_paragraphs:', [[('mainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstre@@', -39.73262023925781)]])
('hypotheses_to_return:', [('mainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstre@@', -39.73262023925781)])
mainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstremainstre@@

[piero:~/Documents/argos-translate] [venv] master* ± git commit -a -m "Revert 5a9ec1e"
[master 13c2130] Revert 5a9ec1e
 2 files changed, 2 deletions(-)

 [piero:~/Documents/argos-translate] [venv] master(1)* ± ARGOS_DEBUG=1 ARGOS_CHUNK_TYPE=STANZA python test_trans.py
('get_installed_languages',)
('paragraphs:', ['Vamos'])
('apply_packaged_translation', 'Vamos')
('Splitting sentences using SBD Model: (es) StanzaSentencizer',)
('sentences', ['Vamos'])
('tokenized', [['Vamos']])
('translated_batches', [TranslationResult(hypotheses=[['Come', 'on', '.']], scores=[-0.7667394280433655], attention=[], logits=[])])
('value_hypotheses:', [('Come on.', -0.7667394280433655)])
('translated_paragraphs:', [[('Come on.', -0.7667394280433655)]])
('hypotheses_to_return:', [('Come on.', -0.7667394280433655)])
Come on.
```