### PR TITLE
Add MPS (Apple Silicon) GPU support and auto device detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ The GUI code is in a [separate repository](https://github.com/argosopentech/argo
 
 ### GPU Acceleration
 
-To enable GPU support, you need to set the `ARGOS_DEVICE_TYPE` env variable to `cuda` or `auto`.
+To enable GPU support, you need to set the `ARGOS_DEVICE_TYPE` env variable to `cuda`, `auto`, or `mps`.
 
 ```
 $ ARGOS_DEVICE_TYPE=cuda argos-translate --from-lang en --to-lang es "Hello World"
 Hola Mundo
 ```
 
-The above env variable passes the device type to [CTranslate2](https://github.com/OpenNMT/CTranslate2).
+The above env variable passes the device type to [CTranslate2](https://github.com/OpenNMT/CTranslate2) and SBD models. Use `mps` for Apple Silicon GPU acceleration.
 
 ### HTML Translation
 The [translate-html](https://github.com/argosopentech/translate-html) library is built on top of Argos Translate and [Beautiful Soup](https://beautiful-soup-4.readthedocs.io/en/latest/) and parses and translates HTML. The LibreTranslate API also has support for translating HTML.

--- a/argostranslate/settings.py
+++ b/argostranslate/settings.py
@@ -133,15 +133,8 @@ remote_package_index = package_index + "index.json"
 
 local_package_index = data_dir / "index.json"
 
-# Supported values: "cpu" and "cuda"
-device = get_setting("ARGOS_DEVICE_TYPE", "cpu")
-
-# https://opennmt.net/CTranslate2/python/ctranslate2.Translator.html
-inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))
-intra_threads = int(get_setting("ARGOS_INTRA_THREADS", "0"))
-
-# Supported values: "cpu" and "cuda"
-device = get_setting("ARGOS_DEVICE_TYPE", "cpu")
+# Supported values: "cpu", "cuda", "auto", "mps"
+device = get_setting("ARGOS_DEVICE_TYPE", "auto")
 
 # https://opennmt.net/CTranslate2/python/ctranslate2.Translator.html
 inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))

--- a/argostranslate/translate.py
+++ b/argostranslate/translate.py
@@ -18,6 +18,19 @@ from argostranslate.sbd import SpacySentencizerSmall
 from argostranslate.utils import error, info, warning
 
 
+def _resolve_device(device_setting: str) -> str:
+    """Resolve 'auto' to the best available device (cuda > mps > cpu)."""
+    if device_setting != "auto":
+        return device_setting
+    for candidate in ("cuda", "mps"):
+        try:
+            if ctranslate2.get_supported_compute_types(candidate):
+                return candidate
+        except Exception:
+            pass
+    return "cpu"
+
+
 class Hypothesis:
     """Represents a translation hypothesis
 
@@ -283,7 +296,7 @@ def chunk(from_text, from_code):
 
         model_path = str(chunk_package.package_path / "model")
         ctranslate2_translator = ctranslate2.Translator(
-            model_path, device=argostranslate.settings.device
+            model_path, device=_resolve_device(argostranslate.settings.device)
         )
         sp_model_path = str(chunk_package.package_path / "sentencepiece.model")
         sp_processor = sentencepiece.SentencePieceProcessor(
@@ -329,7 +342,7 @@ class Translator:
         ]
         self.model_path = self.pkg.package_path / "model"
         self.translator = ctranslate2.Translator(
-            str(self.model_path), device=argostranslate.settings.device
+            str(self.model_path), device=_resolve_device(argostranslate.settings.device)
         )
         self.sp_model_path = self.pkg.package_path / "sentencepiece.model"
         self.sp_processor = sentencepiece.SentencePieceProcessor(

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -23,4 +23,6 @@ export ARGOS_PACKAGES_DIR="/home/user/.local/share/argos-translate/packages/"
 ```
 export ARGOS_DEVICE_TYPE="cpu"
 export ARGOS_DEVICE_TYPE="cuda"
+export ARGOS_DEVICE_TYPE="auto"
+export ARGOS_DEVICE_TYPE="mps"
 ```

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -35,3 +35,5 @@ Set device
 
   export ARGOS_DEVICE_TYPE="cpu"
   export ARGOS_DEVICE_TYPE="cuda"
+  export ARGOS_DEVICE_TYPE="auto"
+  export ARGOS_DEVICE_TYPE="mps"

--- a/tests/unit-tests/test_device_resolution.py
+++ b/tests/unit-tests/test_device_resolution.py
@@ -1,0 +1,102 @@
+import pathlib
+import unittest.mock
+
+import argostranslate.package
+import argostranslate.settings
+import argostranslate.translate
+
+
+class TestResolveDevice:
+    def test_passthrough_cpu(self):
+        assert argostranslate.translate._resolve_device("cpu") == "cpu"
+
+    def test_passthrough_cuda(self):
+        assert argostranslate.translate._resolve_device("cuda") == "cuda"
+
+    def test_passthrough_mps(self):
+        assert argostranslate.translate._resolve_device("mps") == "mps"
+
+    def test_auto_selects_cuda_first(self):
+        def compute_types(device):
+            if device == "cuda":
+                return {"float32", "int8"}
+            raise RuntimeError("device not available")
+
+        with unittest.mock.patch(
+            "ctranslate2.get_supported_compute_types", side_effect=compute_types
+        ):
+            assert argostranslate.translate._resolve_device("auto") == "cuda"
+
+    def test_auto_selects_mps_when_cuda_unavailable(self):
+        def compute_types(device):
+            if device == "cuda":
+                raise RuntimeError("CUDA not available")
+            if device == "mps":
+                return {"float32"}
+            raise RuntimeError("device not available")
+
+        with unittest.mock.patch(
+            "ctranslate2.get_supported_compute_types", side_effect=compute_types
+        ):
+            assert argostranslate.translate._resolve_device("auto") == "mps"
+
+    def test_auto_falls_back_to_cpu_when_no_gpu(self):
+        with unittest.mock.patch(
+            "ctranslate2.get_supported_compute_types",
+            side_effect=RuntimeError("no GPU"),
+        ):
+            assert argostranslate.translate._resolve_device("auto") == "cpu"
+
+    def test_auto_falls_back_to_cpu_when_empty_compute_types(self):
+        with unittest.mock.patch(
+            "ctranslate2.get_supported_compute_types", return_value=set()
+        ):
+            assert argostranslate.translate._resolve_device("auto") == "cpu"
+
+
+class TestTranslatorDevice:
+    def get_mock_package(self):
+        package = unittest.mock.Mock(spec=argostranslate.package.Package)
+        package.package_path = pathlib.Path("test_package_path")
+        package.source_languages = [{"code": "en", "name": "English"}]
+        package.target_languages = [{"code": "es", "name": "Spanish"}]
+        return package
+
+    @unittest.mock.patch("argostranslate.settings.device", "mps")
+    @unittest.mock.patch("sentencepiece.SentencePieceProcessor")
+    @unittest.mock.patch("ctranslate2.Translator")
+    def test_translator_init_mps(self, mock_translator, _mock_sp):
+        argostranslate.translate.Translator(self.get_mock_package())
+        mock_translator.assert_called_once_with(
+            str(pathlib.Path("test_package_path/model")), device="mps"
+        )
+
+    @unittest.mock.patch("argostranslate.settings.device", "auto")
+    @unittest.mock.patch("sentencepiece.SentencePieceProcessor")
+    @unittest.mock.patch("ctranslate2.Translator")
+    def test_translator_init_auto_uses_cuda_when_available(
+        self, mock_translator, _mock_sp
+    ):
+        with unittest.mock.patch(
+            "ctranslate2.get_supported_compute_types", return_value={"float32"}
+        ):
+            argostranslate.translate.Translator(self.get_mock_package())
+        mock_translator.assert_called_once_with(
+            str(pathlib.Path("test_package_path/model")), device="cuda"
+        )
+
+    @unittest.mock.patch("argostranslate.settings.device", "auto")
+    @unittest.mock.patch("sentencepiece.SentencePieceProcessor")
+    @unittest.mock.patch("ctranslate2.Translator")
+    def test_translator_init_auto_falls_back_to_cpu(self, mock_translator, _mock_sp):
+        with unittest.mock.patch(
+            "ctranslate2.get_supported_compute_types",
+            side_effect=RuntimeError("no GPU"),
+        ):
+            argostranslate.translate.Translator(self.get_mock_package())
+        mock_translator.assert_called_once_with(
+            str(pathlib.Path("test_package_path/model")), device="cpu"
+        )
+
+    def test_default_device_is_auto(self):
+        assert argostranslate.settings.device == "auto"


### PR DESCRIPTION

This pull request adds support for Apple Silicon GPU acceleration via Metal Performance Shaders (MPS) by expanding device selection logic throughout the codebase. It introduces a new `auto` device setting that automatically selects the best available device (`cuda` > `mps` > `cpu`), updates documentation to reflect these changes, and adds comprehensive unit tests for device resolution logic.

**Device selection improvements:**

* Added a `_resolve_device` function in `argostranslate/translate.py` that resolves the `auto` device setting to the best available device, preferring `cuda`, then `mps`, and finally `cpu` if no GPU is available. This function is now used when initializing CTranslate2 translators. [[1]](diffhunk://#diff-496f3471b368e65fa4389c8c786e27cc7d7e10475efbf8652ef8f692006df031R21-R33) [[2]](diffhunk://#diff-496f3471b368e65fa4389c8c786e27cc7d7e10475efbf8652ef8f692006df031L286-R299) [[3]](diffhunk://#diff-496f3471b368e65fa4389c8c786e27cc7d7e10475efbf8652ef8f692006df031L332-R345)
* Updated the default value of `ARGOS_DEVICE_TYPE` in `argostranslate/settings.py` from `"cpu"` to `"auto"`, and expanded supported values to include `"mps"` for Apple Silicon support.

**Documentation updates:**

* Updated documentation files (`README.md`, `docs/settings.md`, `docs/source/settings.rst`) to mention the new `auto` and `mps` options for `ARGOS_DEVICE_TYPE` and clarified usage for Apple Silicon GPU acceleration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R127) [[2]](diffhunk://#diff-cd5ab0390b5750a658337173d28e15c9631a156470fb8036633f3fefc4bf96a4R26-R27) [[3]](diffhunk://#diff-ee2ed952368c143a88b12abef20e06a47bfc26d8e4c6c89fe2de2a354c423b78R38-R39)

**Testing improvements:**

* Added a new test file `tests/unit-tests/test_device_resolution.py` with unit tests for the `_resolve_device` function and for device selection during translator initialization, covering all supported device types and fallback scenarios.
- Document "auto" and "mps" device options in README, settings.md, settings.rst
- Add 11 unit tests covering all _resolve_device() branches and Translator device selection (mps passthrough, auto→cuda, auto→cpu)