### PR TITLE
refactor(sbd): make stanza pipeline truly lazy

### DIFF
--- a/argostranslate/sbd.py
+++ b/argostranslate/sbd.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     spacy = None
 
-import stanza
 from minisbd import SBDetect, models as minisbd_models
 
 from argostranslate import package, settings
@@ -145,6 +144,8 @@ class StanzaSentencizer(ISentenceBoundaryDetectionModel):
         self.stanza_pipeline = None
     
     def lazy_pipeline(self):
+        import stanza
+
         if self.stanza_pipeline is None:
             self.stanza_pipeline = stanza.Pipeline(
                 lang=self.stanza_lang_code,


### PR DESCRIPTION
# Change description

Hi, I'm working on a project using argos-translate.
I'm building docker images which I'd like to be as light as possible, sadly argos is fetching the full torch stack through stanza which I don't plan to use (I'm using spacy). The stack is about 1GB on CPU and goes up to 4GB if you're fetching torch on Nvidia GPU index.

Ideally I'd like to install argos with a lighweight SBD (probably `MiniSBD`), and using python `extra` specifiers to add support for optional SBDs (stanza or spacy). But that's a big change and a breaking one as users will now how to install argos with extras if they want stanza support (spacy already seem to be optional).

Instead of this breaking change (which could be implementer later), I propose to make `stanza` loading truly lazy and hence replace `stanza` global import by a local one. This way nothing break and use which want to exclude torch/stanza from their installation / local env can still use the lib.

It's not ideal but probably a nice first step.
If you prefer the other option I can also implement it, please let me know.


# Changes

## Changed
- made `stanza` import lazy but importing the lib locally instead of globally
