### PR TITLE
Default CTranslate2 intra threads to 1 on macOS

### DIFF
--- a/argostranslate/settings.py
+++ b/argostranslate/settings.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict
@@ -168,7 +169,12 @@ device = get_setting("ARGOS_DEVICE_TYPE", "cpu")
 
 # https://opennmt.net/CTranslate2/python/ctranslate2.Translator.html
 inter_threads = int(get_setting("ARGOS_INTER_THREADS", "1"))
-intra_threads = int(get_setting("ARGOS_INTRA_THREADS", "0"))
+# On macOS no-OpenMP CTranslate2 wheels, the backend default can fan out into
+# many CPU worker threads for small translation batches. Default to one backend
+# compute thread on Darwin while still allowing explicit user overrides.
+intra_threads = int(
+    get_setting("ARGOS_INTRA_THREADS", "1" if sys.platform == "darwin" else "0")
+)
 batch_size = int(get_setting("ARGOS_BATCH_SIZE", "32"))
 compute_type = get_setting("ARGOS_COMPUTE_TYPE", "auto")
 beam_size = int(get_setting("ARGOS_BEAM_SIZE", "4"))


### PR DESCRIPTION
## Summary

Default `ARGOS_INTRA_THREADS` to `1` on Darwin instead of `0`.

This keeps the existing behavior on non-macOS platforms and still allows users to override the value explicitly with `ARGOS_INTRA_THREADS`.

## Why

On macOS no-OpenMP CTranslate2 wheels, `intra_threads=0` delegates to the backend default. In local testing with Argos Translate + CTranslate2 on macOS arm64, that backend auto-threading path fanned out into CPU worker pools and performed poorly for Argos' typical workload of many small paragraph/sentence translation batches.

It also reproduced a native abort on CTranslate2 4.7.2 / Python 3.14.5:

```text
libc++abi: terminating due to uncaught exception of type std::__1::system_error:
condition_variable wait failed: Invalid argument
```

The crash report showed:

```text
BS::thread_pool_light::worker()
std::__1::condition_variable::wait(...)
ctranslate2::python::TranslatorWrapper::translate_batch(...)
```

## Validation

Environment:

```text
macOS 26.5.1 arm64
Python 3.14.5
Argos Translate current settings module
CTranslate2 4.8.0
English -> Russian Argos model
```

Benchmark on the same 30-unit Markdown slice:

```text
intra=0  TIMEOUT >60s
intra=1  elapsed=31.012s user=36.103s  sys=0.120s
intra=2  elapsed=48.529s user=84.297s  sys=19.564s
intra=4  elapsed=38.526s user=139.771s sys=28.153s
intra=8  elapsed=37.895s user=275.805s sys=28.084s
```

Full sustained regression with `intra_threads=1`:

```text
units 749
chars 197463
ALL DONE 749 791.3
```

This makes `1` a safer and faster Darwin default for the tested Argos workload while preserving explicit user control.
