### PR TITLE
Fix typo in argos-translate (#525)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ rm -r ~/.local/share/argos-translate
 ## Related Projects
 - [LibreTranslate-py](https://github.com/argosopentech/LibreTranslate-py) - Python bindings for LibreTranslate
 - [MetalTranslate](https://github.com/argosopentech/MetalTranslate) - Customizable translation in C++
-- [LibreTranslate/Locomotive](https://github.com/LibreTranslate/Locomotive) - Toolkit for training/converting LibreTranslate compatible language models 🚂 
+- [LibreTranslate/Locomotive](https://github.com/LibreTranslate/Locomotive) - Toolkit for training/converting LibreTranslate compatible language models 🚂
 - [DesktopTranslator](https://github.com/ymoslem/DesktopTranslator) - [OpenNMT](https://opennmt.net/) based translation application
 - [LibreTranslate-rs](https://github.com/grantshandy/libretranslate-rs) - LibreTranslate Rust bindings
 - [LibreTranslate Go](https://github.com/SnakeSel/libretranslate) - LibreTranslate Golang bindings

--- a/data_snap/snap/snapcraft.yaml
+++ b/data_snap/snap/snapcraft.yaml
@@ -21,4 +21,4 @@ slots:
     content: argos-packages
     source:
       read:
-        - $SNAP/packages 
+        - $SNAP/packages

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -8,7 +8,7 @@ export ARGOS_PACKAGE_INDEX="https://raw.githubusercontent.com/argosopentech/argo
 
 #### View debugging information
 
-Argos Translate prints more verbose logging 
+Argos Translate prints more verbose logging
 
 ```
 export ARGOS_DEBUG=1

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -5,13 +5,13 @@ Command Line Interface
 
   argos-translate --from-lang en --to-lang es "Hello World"
   Hola Mundo
-  
+
   echo "Text to translate" | argos-translate --from-lang en --to-lang es
   Texto para traducir
 
   argospm --help
   usage: argospm [-h] {update,search,install,list,remove} ...
-  
+
   positional arguments:
     {update,search,install,list,remove}
                           Available commands.
@@ -20,10 +20,10 @@ Command Line Interface
       install             Install package.
       list                List installed packages.
       remove              Remove installed package.
-  
+
   optional arguments:
     -h, --help            show this help message and exit
-    
+
 
 
 Translate a string from English to Spanish.
@@ -59,14 +59,14 @@ Downloads remote package index.
 .. code-block:: sh
 
   argospm update
-		
+
 Search
 ------
 Search package from remote index.
 
 .. code-block:: sh
 
-  argospm search --from-lang en --to-lang es		
+  argospm search --from-lang en --to-lang es
 
 Install
 ------
@@ -75,7 +75,7 @@ Install package.
 .. code-block:: sh
 
   argospm install translate-en_es
-		
+
 List
 ------
 List installed packages.
@@ -83,7 +83,7 @@ List installed packages.
 .. code-block:: sh
 
   argospm list
-		
+
 Remove
 ------
 Remove installed package.
@@ -91,15 +91,15 @@ Remove installed package.
 .. code-block:: sh
 
   argospm remove translate-en_es
-		
+
 Enable tab completion for Bash
 ------------------------------
 
 .. code-block:: bash
 
   curl -sSL https://raw.githubusercontent.com/argosopentech/argos-translate/master/scripts/completion.bash > /etc/bash_completion.d/argospm.bash
-  
-  
+
+
 Importing new pairs through the CLI
 ------
 
@@ -112,7 +112,7 @@ For example, install Turkish to English pair: `argospm install translate-tr_en`
 Optionally, you could install all language pairs using BASH.::
 
     for i in $(argospm search | sed 's/:.*$//g'); do argospm install $i ; done
-    
+
 
 
 Removing a pair through the CLI

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -32,9 +32,9 @@ Install package from file path
 .. code-block:: python
 
         import pathlib
-        
+
         import argostranslate.package
-        
+
         package_path = pathlib.Path("/root/translate-en_it-2_0.argosmodel")
-         
+
         argostranslate.package.install_from_path(package_path)

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -15,7 +15,7 @@ Reads package index at https://raw.githubusercontent.com/argosopentech/argospm-i
 View debugging information
 --------------------------
 
-Argos Translate prints more verbose logging 
+Argos Translate prints more verbose logging
 
 .. code-block:: sh
 


### PR DESCRIPTION
I addressed this issue with a small, targeted fix and kept scope limited to the reported area.

Related to #525.